### PR TITLE
Add Authorization Rules

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,4 @@ group :test do
 end
 
 gem 'devise', '~> 4.9'
+gem 'cancancan'

--- a/Gemfile
+++ b/Gemfile
@@ -74,5 +74,5 @@ group :test do
   gem 'webdrivers'
 end
 
-gem 'devise', '~> 4.9'
 gem 'cancancan'
+gem 'devise', '~> 4.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    cancancan (3.5.0)
     capybara (3.39.2)
       addressable
       matrix
@@ -280,6 +281,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  cancancan
   capybara
   debug
   devise (~> 4.9)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -15,6 +15,12 @@ class CommentsController < ApplicationController
     end
   end
 
+  def destroy
+    @comment = Comment.find(params[:id])
+    @comment.destroy
+    respond_to(&:turbo_stream)
+  end
+
   private
 
   def comment_params

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -25,6 +25,20 @@ class PostsController < ApplicationController
     end
   end
 
+  def destroy
+    begin
+      @post = Post.find(params[:id])
+      @user = @post.author
+      if @post.destroy
+        redirect_to user_path(@user), notice: 'Post was deleted.'
+      else
+        redirect_to user_path(@user), alert: 'Error deleting the post.'
+      end
+    rescue ActiveRecord::InvalidForeignKey => e
+      redirect_to user_path(@user), alert: 'Error deleting the post: There are associated comments.'
+    end
+  end
+
   private
 
   def post_params

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -26,17 +26,15 @@ class PostsController < ApplicationController
   end
 
   def destroy
-    begin
-      @post = Post.find(params[:id])
-      @user = @post.author
-      if @post.destroy
-        redirect_to user_path(@user), notice: 'Post was deleted.'
-      else
-        redirect_to user_path(@user), alert: 'Error deleting the post.'
-      end
-    rescue ActiveRecord::InvalidForeignKey => e
-      redirect_to user_path(@user), alert: 'Error deleting the post: There are associated comments.'
+    @post = Post.find(params[:id])
+    @user = @post.author
+    if @post.destroy
+      redirect_to user_path(@user), notice: 'Post was deleted.'
+    else
+      redirect_to user_path(@user), alert: 'Error deleting the post.'
     end
+  rescue ActiveRecord::InvalidForeignKey
+    redirect_to user_path(@user), alert: 'Error deleting the post: There are associated comments.'
   end
 
   private

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,22 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    can :show, Post
+    can :index, Post
+
+    return unless user.present?
+
+    can :new, Post, author: user
+    can :create, Post, author: user
+    can :destroy, Post, author: user
+
+    can :create, Comment, author: user
+    can :destroy, Comment, author: user
+
+    return unless user.role == 'admin'
+
+    can :destroy, Post
+    can :destroy, Comment
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,10 +3,11 @@ class Comment < ApplicationRecord
   belongs_to :post
 
   after_create :update_post_comments_counter
+  after_destroy :update_post_comments_counter
 
   private
 
   def update_post_comments_counter
-    post.increment!(:comments_counter)
+    post.update(comments_counter: post.comments.count)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,9 +8,10 @@ class Post < ApplicationRecord
   has_many :likes
 
   after_create :update_user_posts_counter
+  after_destroy :update_user_posts_counter
 
   def update_user_posts_counter
-    author.increment!(:posts_counter)
+    author.update(posts_counter: author.posts.count)
   end
 
   def recent_comments(limit = 5)

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -15,15 +15,28 @@
   <%= form_with scope: :like, url: post_likes_path(@post) do |form| %>
     <%= form.button "Like Post", class: "btn btn-sm btn-secondary mt-1" %>
   <% end %>
+  <% if can? :destroy, @post %>
+    <%= link_to "Delete this Post", post_path(@post), method: :delete, data: { "turbo-method": :delete }, class: "btn btn-sm btn-danger my-3" %>
+  <% end %>
   </div>
 
   <div class="rounded-bottom p-3 mb-5 comments">
     <% @comments.each do |comment| %>
     <div>
-      <strong><%= comment.author.name %></strong> : <%= comment.text %>
-    </div>
-    <% end %>
+    <div class="container">
+      <div class="row justify-content-between">
+      <% comment.author.name %>
+    : <%= comment.text %>
+    <span>
+      <% if can? :destroy, comment %>
+        <%= link_to "Delete comment", comment_path(comment.id), method: :delete, data: { "turbo-method": :delete }, class: "btn btn-sm btn-danger" %>
+      <% end %>
+    </span>
   </div>
+</div>
+
+    <% end %>
+  </div> <br>
 
   <%= form_with scope: :comment, url: post_comments_path(@post) do |form| %>
     <div class="mb-3">
@@ -37,9 +50,4 @@
 
 <div class="d-flex justify-content-center">
   <%= link_to "Back to all posts", user_posts_path(@post.author), class: "btn btn-primary" %>
-</div>
-
-<div class="d-flex justify-content-center">
-  <span class="text-success"><%= notice %></span>
-  <span class="text-danger"><%= alert %></span>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,14 @@
 Rails.application.routes.draw do
-  devise_for :users, controllers: {
-        sessions: 'users/sessions'
-      }
+  devise_for :users
 
   root "users#index"
 
-    resources :users, only: [:index, :show] do
+  resources :users, only: [:index, :show] do
     resources :posts, only: [:index, :show]
   end
 
-  resources :posts, only: [:new, :create]
+  resources :posts, only: [:new, :create, :destroy]
+  resources :comments, only: [:destroy]
 
   post '/posts/:post_id/comments', to: 'comments#create', as: 'post_comments'
   post '/posts/:post_id/likes', to: 'likes#create', as: 'post_likes'

--- a/db/migrate/20231007091559_add_role_to_users.rb
+++ b/db/migrate/20231007091559_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_04_134629) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_07_091559) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,6 +60,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_04_134629) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "role"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## Adding CanCanCan and Implementing Authorization for Post and Comment Deletion

### Description
This pull request implements the following requirements:
- Installed CanCanCan for authorization.
- Added a `role` column to the `users` table using a migration.
- Implemented authorization for post deletion based on user roles.
- Added a "Delete" button to the post view for authorized users.
- Implemented authorization for comment deletion based on user roles.
- Added a "Delete" button to the comment view for authorized users.

### Changes Made
- Installed CanCanCan gem and configured it for authorization.
- Added a migration to add a `role` column to the `users` table.
- Implemented authorization logic for post and comment deletion using CanCanCan.
- Added "Delete" buttons to the post and comment views with appropriate authorization checks.
